### PR TITLE
fix: initial load of active groups

### DIFF
--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -65,6 +65,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   }, []);
 
   const optanonWrapper = React.useCallback(() => {
+    setInitialConsent();
     const OneTrustOnConsentChanged = window?.Optanon?.OnConsentChanged;
     if (OneTrustOnConsentChanged) {
       OneTrustOnConsentChanged((event) => {
@@ -73,13 +74,12 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
         setOneTrust({ consent: activeGroups, isLoaded: true });
       });
     }
-  }, [onConsentChanged]);
+  }, [onConsentChanged, setInitialConsent]);
 
   React.useEffect(() => {
     if (!enabled) return;
     window.OptanonWrapper = optanonWrapper;
-    setInitialConsent();
-  }, [enabled, optanonWrapper, setInitialConsent]);
+  }, [enabled, optanonWrapper]);
 
   const openPreferenceCenter = () => {
     window.OneTrust?.ToggleInfoDisplay();


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

When OneTrust loads, they call `window.OptanonWrapper` once the script has been loaded. This call sets `OnetrustActiveGroups`. Due to some race condition, the initial consent was not always defined because`window.OptanonWrapper` wasn't called yet.
 
This change ensures that OneTrust has been loaded by putting the initial consent read inside the OptanonWrapper function. By checking isLoaded, we make sure it only runs once
