### PR TITLE
feat: provide interacted property

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ enables you to react on changes (e.g. block certain third party scripts).
 <CookieConsentProvider
     enabled={true}
     onConsentChanged={(newConsent) => console.log(newConsent)}
+    onOneTrustLoaded={(initialConsent, hideBanner) => console.log(initialConsent)}
 >
     <div>your app..</div>
 </CookieConsentProvider>
 ```
 
 `onConsentChanged` is optional and allows you to fire events when the user changed the consent in the preference center.
+`onOneTrustLoaded` is optional and is called after OneTrust has been loaded. `hideBanner` is `true` if the banner has
+been shown in a previous session.
 
 ### CookieConsentContext
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ using `CookieConsentContext`.
 ````tsx
 import {CookieConsentContext} from '@smg-automotive/cookie-consent-pkg';
 
-const {consent, openPreferenceCenter, isLoaded} = useContext(CookieConsentContext);
+const {consent, openPreferenceCenter, isLoaded, hasInteracted } = useContext(CookieConsentContext);
 ````
 
 | property             | type       | description                                                                                                                                           |
@@ -66,6 +66,7 @@ const {consent, openPreferenceCenter, isLoaded} = useContext(CookieConsentContex
 | consent              | Category[] | Array of the current consent. If the user uses a script blocker or you disabled OneTrust in the Provider, only the stricly necessary category is set. |
 | openPreferenceCenter | Function   | Opens the OneTrust preference center.                                                                                                                 |
 | isLoaded             | boolean    | True if OneTrust has been successfully loaded and invoked.                                                                                            |
+| hasInteracted        | boolean    | True if the user has interacted with the banner at some point.                                                                                        |
 
 ## Development
 

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -18,12 +18,14 @@ declare global {
 type Context = {
   consent: Category[];
   isLoaded: boolean;
+  hasInteracted: boolean;
   openPreferenceCenter: () => void;
 };
 
 const CookieConsentContext = React.createContext<Context>({
   consent: [],
   isLoaded: false,
+  hasInteracted: false,
   openPreferenceCenter: () => null,
 });
 
@@ -36,6 +38,7 @@ type Props = {
 type OneTrust = {
   consent: Category[];
   isLoaded: boolean;
+  hasInteracted: boolean;
 };
 
 const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
@@ -47,6 +50,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   const [oneTrust, setOneTrust] = React.useState<OneTrust>({
     consent: [Category.StrictlyNecessaryCookies],
     isLoaded: false,
+    hasInteracted: false,
   });
 
   const setInitialConsent = React.useCallback(() => {
@@ -65,6 +69,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
       return {
         consent: initialConsent,
         isLoaded: true,
+        hasInteracted: hideBanner,
       };
     });
   }, [onOneTrustLoaded]);
@@ -76,7 +81,11 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
       OneTrustOnConsentChanged((event) => {
         const activeGroups = event.detail || [];
         onConsentChanged && onConsentChanged(activeGroups);
-        setOneTrust({ consent: activeGroups, isLoaded: true });
+        setOneTrust({
+          consent: activeGroups,
+          isLoaded: true,
+          hasInteracted: true,
+        });
       });
     }
   }, [onConsentChanged, setInitialConsent]);
@@ -96,6 +105,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
         consent: oneTrust.consent,
         openPreferenceCenter,
         isLoaded: oneTrust.isLoaded,
+        hasInteracted: oneTrust.hasInteracted,
       }}
     >
       {children}

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -73,6 +73,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
     const OneTrustOnConsentChanged = window?.Optanon?.OnConsentChanged;
     if (OneTrustOnConsentChanged) {
       OneTrustOnConsentChanged((event) => {
+        /* eslint-disable-next-line no-console */
         console.log(event);
         const activeGroups = event.detail || [];
         onConsentChanged && onConsentChanged(activeGroups);

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -30,7 +30,7 @@ const CookieConsentContext = React.createContext<Context>({
 type Props = {
   enabled: boolean;
   onConsentChanged?: (newConsent: Category[]) => void;
-  onOneTrustLoaded?: (consent: Category[], showBanner: boolean) => void;
+  onOneTrustLoaded?: (consent: Category[], hideBanner: boolean) => void;
 };
 
 type OneTrust = {
@@ -60,8 +60,8 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
         oneTrustActiveGroups && oneTrustActiveGroups.length
           ? oneTrustActiveGroups
           : prevOneTrust.consent;
-      const showBanner = document.cookie.includes('OptanonAlertBoxClosed');
-      onOneTrustLoaded && onOneTrustLoaded(initialConsent, showBanner);
+      const hideBanner = document.cookie.includes('OptanonAlertBoxClosed');
+      onOneTrustLoaded && onOneTrustLoaded(initialConsent, hideBanner);
       return {
         consent: initialConsent,
         isLoaded: true,

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -30,7 +30,7 @@ const CookieConsentContext = React.createContext<Context>({
 type Props = {
   enabled: boolean;
   onConsentChanged?: (newConsent: Category[]) => void;
-  onOneTrustLoaded?: (consent: Category[]) => void;
+  onOneTrustLoaded?: (consent: Category[], showBanner: boolean) => void;
 };
 
 type OneTrust = {
@@ -49,6 +49,20 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
     isLoaded: false,
   });
 
+  const getCookie = (name: string) => {
+    const value = '; ' + document.cookie;
+    /* eslint-disable-next-line no-console */
+    console.log(value);
+    const parts = value.split('; ' + name + '=');
+    /* eslint-disable-next-line no-console */
+    console.log(parts);
+    if (parts && parts.length == 2) {
+      return parts.pop()?.split(';').shift();
+    } else {
+      return null;
+    }
+  };
+
   const setInitialConsent = React.useCallback(() => {
     setOneTrust((prevOneTrust) => {
       if (prevOneTrust.isLoaded) return prevOneTrust;
@@ -60,7 +74,8 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
         oneTrustActiveGroups && oneTrustActiveGroups.length
           ? oneTrustActiveGroups
           : prevOneTrust.consent;
-      onOneTrustLoaded && onOneTrustLoaded(initialConsent);
+      const showBanner = !!getCookie('OptanonAlertBoxClosed');
+      onOneTrustLoaded && onOneTrustLoaded(initialConsent, showBanner);
       return {
         consent: initialConsent,
         isLoaded: true,

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -30,7 +30,7 @@ const CookieConsentContext = React.createContext<Context>({
 type Props = {
   enabled: boolean;
   onConsentChanged?: (newConsent: Category[]) => void;
-  onOneTrustLoaded?: (newConsent: Category[]) => void;
+  onOneTrustLoaded?: (consent: Category[]) => void;
 };
 
 type OneTrust = {
@@ -73,6 +73,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
     const OneTrustOnConsentChanged = window?.Optanon?.OnConsentChanged;
     if (OneTrustOnConsentChanged) {
       OneTrustOnConsentChanged((event) => {
+        console.log(event);
         const activeGroups = event.detail || [];
         onConsentChanged && onConsentChanged(activeGroups);
         setOneTrust({ consent: activeGroups, isLoaded: true });

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -49,20 +49,6 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
     isLoaded: false,
   });
 
-  const getCookie = (name: string) => {
-    const value = '; ' + document.cookie;
-    /* eslint-disable-next-line no-console */
-    console.log(value);
-    const parts = value.split('; ' + name + '=');
-    /* eslint-disable-next-line no-console */
-    console.log(parts);
-    if (parts && parts.length == 2) {
-      return parts.pop()?.split(';').shift();
-    } else {
-      return null;
-    }
-  };
-
   const setInitialConsent = React.useCallback(() => {
     setOneTrust((prevOneTrust) => {
       if (prevOneTrust.isLoaded) return prevOneTrust;
@@ -74,7 +60,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
         oneTrustActiveGroups && oneTrustActiveGroups.length
           ? oneTrustActiveGroups
           : prevOneTrust.consent;
-      const showBanner = !!getCookie('OptanonAlertBoxClosed');
+      const showBanner = document.cookie.includes('OptanonAlertBoxClosed');
       onOneTrustLoaded && onOneTrustLoaded(initialConsent, showBanner);
       return {
         consent: initialConsent,

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -30,6 +30,7 @@ const CookieConsentContext = React.createContext<Context>({
 type Props = {
   enabled: boolean;
   onConsentChanged?: (newConsent: Category[]) => void;
+  onOneTrustLoaded?: (newConsent: Category[]) => void;
 };
 
 type OneTrust = {
@@ -40,6 +41,7 @@ type OneTrust = {
 const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   enabled,
   onConsentChanged,
+  onOneTrustLoaded,
   children,
 }) => {
   const [oneTrust, setOneTrust] = React.useState<OneTrust>({
@@ -54,15 +56,17 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
       const oneTrustActiveGroups = (
         window.OnetrustActiveGroups?.split(',') as Category[]
       )?.filter(Boolean);
+      const initialConsent =
+        oneTrustActiveGroups && oneTrustActiveGroups.length
+          ? oneTrustActiveGroups
+          : prevOneTrust.consent;
+      onOneTrustLoaded && onOneTrustLoaded(initialConsent);
       return {
-        consent:
-          oneTrustActiveGroups && oneTrustActiveGroups.length
-            ? oneTrustActiveGroups
-            : prevOneTrust.consent,
+        consent: initialConsent,
         isLoaded: true,
       };
     });
-  }, []);
+  }, [onOneTrustLoaded]);
 
   const optanonWrapper = React.useCallback(() => {
     setInitialConsent();

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -74,8 +74,6 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
     const OneTrustOnConsentChanged = window?.Optanon?.OnConsentChanged;
     if (OneTrustOnConsentChanged) {
       OneTrustOnConsentChanged((event) => {
-        /* eslint-disable-next-line no-console */
-        console.log(event);
         const activeGroups = event.detail || [];
         onConsentChanged && onConsentChanged(activeGroups);
         setOneTrust({ consent: activeGroups, isLoaded: true });

--- a/src/OneTrustCookieConsentBanner.tsx
+++ b/src/OneTrustCookieConsentBanner.tsx
@@ -14,6 +14,7 @@ const OneTrustCookieConsentBanner: FC<Props> = ({ domainScript, enabled }) => {
       script.src = src;
       script.type = 'text/javascript';
       script.dataset.domainScript = domainScript;
+      script.dataset.documentLanguage = 'true';
       script.async = true;
       document.head.appendChild(script);
     }

--- a/src/__tests__/CookieConsent.Test.tsx
+++ b/src/__tests__/CookieConsent.Test.tsx
@@ -81,10 +81,10 @@ describe('CookieConsent', () => {
     });
 
     rerender();
-    expect(onOneTrustLoaded).toHaveBeenCalledWith([
-      Category.PerformanceCookies,
-      Category.FunctionalCookies,
-    ]);
+    expect(onOneTrustLoaded).toHaveBeenCalledWith(
+      [Category.PerformanceCookies, Category.FunctionalCookies],
+      false
+    );
   });
 
   it('changes the consent if the user uses the preference center', () => {

--- a/src/__tests__/CookieConsent.Test.tsx
+++ b/src/__tests__/CookieConsent.Test.tsx
@@ -11,7 +11,7 @@ const wrapper = ({
 }: {
   enabled: boolean;
   onConsentChanged?: (newConsent: Category[]) => void;
-  onOneTrustLoaded?: (newConsent: Category[]) => void;
+  onOneTrustLoaded?: (consent: Category[]) => void;
 }) => {
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <CookieConsentProvider

--- a/src/__tests__/CookieConsent.Test.tsx
+++ b/src/__tests__/CookieConsent.Test.tsx
@@ -11,7 +11,7 @@ const wrapper = ({
 }: {
   enabled: boolean;
   onConsentChanged?: (newConsent: Category[]) => void;
-  onOneTrustLoaded?: (consent: Category[]) => void;
+  onOneTrustLoaded?: (consent: Category[], hideBanner: boolean) => void;
 }) => {
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <CookieConsentProvider
@@ -64,7 +64,7 @@ describe('CookieConsent', () => {
     expect(result.current.isLoaded).toEqual(true);
   });
 
-  it('calls the onOneTrustLoaded with the initial consent', () => {
+  it('calls onOneTrustLoaded with the initial consent', () => {
     const onOneTrustLoaded = jest.fn();
     window.OnetrustActiveGroups = `${Category.PerformanceCookies},${Category.FunctionalCookies}`;
     /* eslint-disable-next-line @typescript-eslint/no-empty-function */

--- a/src/__tests__/CookieConsent.Test.tsx
+++ b/src/__tests__/CookieConsent.Test.tsx
@@ -88,29 +88,6 @@ describe('CookieConsent', () => {
     );
   });
 
-  it('calls onOneTrustLoaded with the initial consent', () => {
-    const onOneTrustLoaded = jest.fn();
-    window.OnetrustActiveGroups = `${Category.PerformanceCookies},${Category.FunctionalCookies}`;
-    /* eslint-disable-next-line @typescript-eslint/no-empty-function */
-    window.OptanonWrapper = function () {};
-    const { rerender } = renderHook(
-      () => React.useContext(CookieConsentContext),
-      {
-        wrapper: wrapper({ enabled: true, onOneTrustLoaded }),
-      }
-    );
-
-    act(() => {
-      (window.OptanonWrapper as () => void)();
-    });
-
-    rerender();
-    expect(onOneTrustLoaded).toHaveBeenCalledWith(
-      [Category.PerformanceCookies, Category.FunctionalCookies],
-      false
-    );
-  });
-
   it('changes the consent if the user uses the preference center', () => {
     const onChange = jest.fn();
     const { result, rerender } = renderHook(

--- a/src/__tests__/CookieConsent.Test.tsx
+++ b/src/__tests__/CookieConsent.Test.tsx
@@ -62,6 +62,7 @@ describe('CookieConsent', () => {
       Category.FunctionalCookies,
     ]);
     expect(result.current.isLoaded).toEqual(true);
+    expect(result.current.hasInteracted).toEqual(false);
   });
 
   it('calls onOneTrustLoaded with the initial consent', () => {
@@ -102,6 +103,7 @@ describe('CookieConsent', () => {
     });
     rerender();
     expect(result.current.isLoaded).toEqual(true);
+    expect(result.current.hasInteracted).toEqual(false);
     expect(result.current.consent).toEqual([Category.StrictlyNecessaryCookies]);
 
     act(() => {
@@ -114,6 +116,7 @@ describe('CookieConsent', () => {
     });
 
     expect(result.current.consent).toEqual([Category.PerformanceCookies]);
+    expect(result.current.hasInteracted).toEqual(true);
     expect(onChange).toHaveBeenCalledWith([Category.PerformanceCookies]);
   });
 

--- a/src/__tests__/CookieConsent.Test.tsx
+++ b/src/__tests__/CookieConsent.Test.tsx
@@ -7,14 +7,17 @@ import { Category } from '../category';
 const wrapper = ({
   enabled,
   onConsentChanged,
+  onOneTrustLoaded,
 }: {
   enabled: boolean;
   onConsentChanged?: (newConsent: Category[]) => void;
+  onOneTrustLoaded?: (newConsent: Category[]) => void;
 }) => {
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <CookieConsentProvider
       enabled={enabled}
       onConsentChanged={onConsentChanged}
+      onOneTrustLoaded={onOneTrustLoaded}
     >
       {children}
     </CookieConsentProvider>
@@ -59,6 +62,29 @@ describe('CookieConsent', () => {
       Category.FunctionalCookies,
     ]);
     expect(result.current.isLoaded).toEqual(true);
+  });
+
+  it('calls the onOneTrustLoaded with the initial consent', () => {
+    const onOneTrustLoaded = jest.fn();
+    window.OnetrustActiveGroups = `${Category.PerformanceCookies},${Category.FunctionalCookies}`;
+    /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+    window.OptanonWrapper = function () {};
+    const { rerender } = renderHook(
+      () => React.useContext(CookieConsentContext),
+      {
+        wrapper: wrapper({ enabled: true, onOneTrustLoaded }),
+      }
+    );
+
+    act(() => {
+      (window.OptanonWrapper as () => void)();
+    });
+
+    rerender();
+    expect(onOneTrustLoaded).toHaveBeenCalledWith([
+      Category.PerformanceCookies,
+      Category.FunctionalCookies,
+    ]);
   });
 
   it('changes the consent if the user uses the preference center', () => {


### PR DESCRIPTION
References https://github.com/smg-automotive/listings-web/pull/107

## Motivation and context

So that we can defer page view events until the user has interacted with the banner, we need this flag.

## Before

No hasInteracted flag

## After

hasInteracted flag

## How to test

1. go to: https://talamcol-track-page-views.listings-web.branch.autoscout24.ch/de/listings/8596652/message-lead
2. clear all cookies
3. reload the page
4. inspect dataLayer -> no page view event
5. press accept all on the still visible banner
6. inspect dataLayer -> page view event is there