### PR TITLE
chore: use latest LTS version (node)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 docker: &DOCKER_NODE
   docker:
-    - image: cimg/node:18.12.0
+    - image: cimg/node:lts
 
 slack_context: &SLACK_NOTIFICATION_CONTEXT
   context:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/*


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

This always uses the latest LTS version
