### PR TITLE
feat: add custom hooks for cookie consent

### DIFF
--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -113,4 +113,15 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   );
 };
 
-export { CookieConsentProvider, CookieConsentContext };
+const useCookieConsent = () => {
+  const context = React.useContext(CookieConsentContext);
+  if (context === undefined) {
+    throw new Error(
+      'useCookieConsent must be used within a CookieConsentProvider'
+    );
+  }
+
+  return context;
+};
+
+export { CookieConsentProvider, CookieConsentContext, useCookieConsent };

--- a/src/__tests__/CookieConsent.Test.tsx
+++ b/src/__tests__/CookieConsent.Test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { act, renderHook } from '@testing-library/react';
 
-import { CookieConsentContext, CookieConsentProvider } from '../CookieConsent';
+import { CookieConsentProvider, useCookieConsent } from '../CookieConsent';
 import { Category } from '../category';
 
 const wrapper = ({
@@ -31,12 +31,9 @@ describe('CookieConsent', () => {
   });
 
   it('sets the consent to strictly necessary if OneTrust is disabled', () => {
-    const { result } = renderHook(
-      () => React.useContext(CookieConsentContext),
-      {
-        wrapper: wrapper({ enabled: false }),
-      }
-    );
+    const { result } = renderHook(useCookieConsent, {
+      wrapper: wrapper({ enabled: false }),
+    });
     expect(result.current.consent).toEqual([Category.StrictlyNecessaryCookies]);
     expect(result.current.isLoaded).toEqual(false);
   });
@@ -45,12 +42,9 @@ describe('CookieConsent', () => {
     window.OnetrustActiveGroups = `${Category.PerformanceCookies},${Category.FunctionalCookies}`;
     /* eslint-disable-next-line @typescript-eslint/no-empty-function */
     window.OptanonWrapper = function () {};
-    const { result, rerender } = renderHook(
-      () => React.useContext(CookieConsentContext),
-      {
-        wrapper: wrapper({ enabled: true }),
-      }
-    );
+    const { result, rerender } = renderHook(useCookieConsent, {
+      wrapper: wrapper({ enabled: true }),
+    });
 
     act(() => {
       (window.OptanonWrapper as () => void)();
@@ -70,12 +64,9 @@ describe('CookieConsent', () => {
     window.OnetrustActiveGroups = `${Category.PerformanceCookies},${Category.FunctionalCookies}`;
     /* eslint-disable-next-line @typescript-eslint/no-empty-function */
     window.OptanonWrapper = function () {};
-    const { rerender } = renderHook(
-      () => React.useContext(CookieConsentContext),
-      {
-        wrapper: wrapper({ enabled: true, onOneTrustLoaded }),
-      }
-    );
+    const { rerender } = renderHook(useCookieConsent, {
+      wrapper: wrapper({ enabled: true, onOneTrustLoaded }),
+    });
 
     act(() => {
       (window.OptanonWrapper as () => void)();
@@ -90,12 +81,9 @@ describe('CookieConsent', () => {
 
   it('changes the consent if the user uses the preference center', () => {
     const onChange = jest.fn();
-    const { result, rerender } = renderHook(
-      () => React.useContext(CookieConsentContext),
-      {
-        wrapper: wrapper({ enabled: true, onConsentChanged: onChange }),
-      }
-    );
+    const { result, rerender } = renderHook(useCookieConsent, {
+      wrapper: wrapper({ enabled: true, onConsentChanged: onChange }),
+    });
 
     // simulate OneTrustLoaded
     act(() => {
@@ -123,12 +111,9 @@ describe('CookieConsent', () => {
   it('opens the OneTrust preference center', () => {
     const openPreferenceCenter = jest.fn();
     window.OneTrust = { ToggleInfoDisplay: openPreferenceCenter };
-    const { result } = renderHook(
-      () => React.useContext(CookieConsentContext),
-      {
-        wrapper: wrapper({ enabled: true }),
-      }
-    );
+    const { result } = renderHook(useCookieConsent, {
+      wrapper: wrapper({ enabled: true }),
+    });
     result.current.openPreferenceCenter();
     expect(openPreferenceCenter).toHaveBeenCalled();
   });


### PR DESCRIPTION
References [FE-144](https://autoricardo.atlassian.net/browse/FE-144)

## Motivation and context

Instead of calling useContext(ConsentContext), we can call in relevant app exported custom hook `useCookieConsent`

## Before

No custom hook

## After

With custom hook

## How to test

[Add a deep link and instructions how to verify the new behavior]
