### PR TITLE
fix: remove async loading for OneTrust banner

### DIFF
--- a/src/OneTrustCookieConsentBanner.tsx
+++ b/src/OneTrustCookieConsentBanner.tsx
@@ -15,7 +15,6 @@ const OneTrustCookieConsentBanner: FC<Props> = ({ domainScript, enabled }) => {
       script.type = 'text/javascript';
       script.dataset.domainScript = domainScript;
       script.dataset.documentLanguage = 'true';
-      script.async = true;
       document.head.appendChild(script);
     }
   }, [enabled, domainScript]);

--- a/src/OneTrustCookieConsentBanner.tsx
+++ b/src/OneTrustCookieConsentBanner.tsx
@@ -15,7 +15,7 @@ const OneTrustCookieConsentBanner: FC<Props> = ({ domainScript, enabled }) => {
       script.type = 'text/javascript';
       script.dataset.domainScript = domainScript;
       script.dataset.documentLanguage = 'true';
-      document.head.appendChild(script);
+      document.head.insertBefore(script, document.head.firstChild);
     }
   }, [enabled, domainScript]);
 


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/DM-1796

## Motivation and context

As per documentation, the OneTrust script should be the first element of the head and should not be async. We hope to improve loading speed for the ads with that.

