### PR TITLE
fix: execute OptanonWrapper manually in case OneTrust was loaded before react was ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ npm install @smg-automotive/cookie-consent-pkg
 
 ### Loading OneTrust banner
 
+`OneTrustCookieConsentBanner` adds the required script tags to the document head and preloads the script so that it
+loads as early as possible. only loads a 3KB script. All subsequent scripts load [async](https://developer.onetrust.com/onetrust/docs/performance-availability-cookie-script#description).
+
 ```tsx
 import { OneTrustCookieConsentBanner } from '@smg-automotive/cookie-consent-pkg';
 
+// loads using JavaScript. You may gain more performance by adding it manually to the server HTML
 <OneTrustCookieConsentBanner domainScript="yourScriptID" enabled={true} />;
 ```
 
-`OneTrustCookieConsentBanner` adds the required script tags to the document head and preloads the script so that it
-loads as early as possible. Alternatively, if you are in a Next.js environment, you can add the following to the \_
-document.tsx component:
+ Alternatively, if you are serving an HTML from the server, consider adding it manually inside the document head.
 
 ```tsx
-import Script from 'next/script';
-
-<Script
-  src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
-  data-domain-script="yourScriptID"
-  strategy="beforeInteractive"
-/>;
+<script
+    src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+    data-domain-script="yourScriptID"
+    data-document-language="true"
+/>
 ```
 
 ### CookieConsentProvider

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -86,6 +86,8 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   }, [onOneTrustLoaded]);
 
   const optanonWrapper = React.useCallback(() => {
+    // eslint-disable-next-line no-console
+    console.log('optanonWrapper called');
     setInitialConsent();
     const OneTrustOnConsentChanged = window?.Optanon?.OnConsentChanged;
     if (OneTrustOnConsentChanged) {
@@ -102,6 +104,8 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   }, [onConsentChanged, setInitialConsent]);
 
   React.useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log('effect runs', enabled);
     if (!enabled) return;
     window.OptanonWrapper = optanonWrapper;
   }, [enabled, optanonWrapper]);

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -54,11 +54,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   });
 
   const setInitialConsent = React.useCallback(() => {
-    // eslint-disable-next-line no-console
-    console.log('setting initial consent');
     setOneTrust((prevOneTrust) => {
-      // eslint-disable-next-line no-console
-      console.log({ prevOneTrust });
       if (prevOneTrust.isLoaded) return prevOneTrust;
 
       const oneTrustActiveGroups = (
@@ -71,12 +67,6 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
       const hideBanner = document.cookie.includes('OptanonAlertBoxClosed');
       onOneTrustLoaded && onOneTrustLoaded(initialConsent, hideBanner);
 
-      // eslint-disable-next-line no-console
-      console.log({
-        consent: initialConsent,
-        isLoaded: true,
-        hasInteracted: hideBanner,
-      });
       return {
         consent: initialConsent,
         isLoaded: true,
@@ -86,8 +76,6 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   }, [onOneTrustLoaded]);
 
   const optanonWrapper = React.useCallback(() => {
-    // eslint-disable-next-line no-console
-    console.log('optanonWrapper called');
     setInitialConsent();
     const OneTrustOnConsentChanged = window?.Optanon?.OnConsentChanged;
     if (OneTrustOnConsentChanged) {
@@ -104,10 +92,21 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   }, [onConsentChanged, setInitialConsent]);
 
   React.useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log('effect runs', enabled);
     if (!enabled) return;
-    window.OptanonWrapper = optanonWrapper;
+
+    /*
+     * 1. OneTrust loads the consent banner
+     * 2. When OneTrust finishes loading, it calls the window.OptanonWrapper function
+     *
+     * When OneTrust was loaded before React was ready, OptanonWrapper is not overwritten.
+     * In that case, we call OptanonWrapper manually
+     * */
+    const oneTrustAlreadyLoaded = typeof window.Optanon === 'object';
+    if (oneTrustAlreadyLoaded) {
+      optanonWrapper();
+    } else {
+      window.OptanonWrapper = optanonWrapper;
+    }
   }, [enabled, optanonWrapper]);
 
   const openPreferenceCenter = () => {

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -55,10 +55,10 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
 
   const setInitialConsent = React.useCallback(() => {
     // eslint-disable-next-line no-console
-    console.log("setting initial consent")
+    console.log('setting initial consent');
     setOneTrust((prevOneTrust) => {
       // eslint-disable-next-line no-console
-      console.log({prevOneTrust})
+      console.log({ prevOneTrust });
       if (prevOneTrust.isLoaded) return prevOneTrust;
 
       const oneTrustActiveGroups = (
@@ -76,7 +76,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
         consent: initialConsent,
         isLoaded: true,
         hasInteracted: hideBanner,
-      })
+      });
       return {
         consent: initialConsent,
         isLoaded: true,

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -54,8 +54,10 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   });
 
   const setInitialConsent = React.useCallback(() => {
+    // eslint-disable-next-line no-console
     console.log("setting initial consent")
     setOneTrust((prevOneTrust) => {
+      // eslint-disable-next-line no-console
       console.log({prevOneTrust})
       if (prevOneTrust.isLoaded) return prevOneTrust;
 
@@ -69,6 +71,7 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
       const hideBanner = document.cookie.includes('OptanonAlertBoxClosed');
       onOneTrustLoaded && onOneTrustLoaded(initialConsent, hideBanner);
 
+      // eslint-disable-next-line no-console
       console.log({
         consent: initialConsent,
         isLoaded: true,

--- a/src/CookieConsent.tsx
+++ b/src/CookieConsent.tsx
@@ -54,7 +54,9 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
   });
 
   const setInitialConsent = React.useCallback(() => {
+    console.log("setting initial consent")
     setOneTrust((prevOneTrust) => {
+      console.log({prevOneTrust})
       if (prevOneTrust.isLoaded) return prevOneTrust;
 
       const oneTrustActiveGroups = (
@@ -66,6 +68,12 @@ const CookieConsentProvider: React.FC<React.PropsWithChildren<Props>> = ({
           : prevOneTrust.consent;
       const hideBanner = document.cookie.includes('OptanonAlertBoxClosed');
       onOneTrustLoaded && onOneTrustLoaded(initialConsent, hideBanner);
+
+      console.log({
+        consent: initialConsent,
+        isLoaded: true,
+        hasInteracted: hideBanner,
+      })
       return {
         consent: initialConsent,
         isLoaded: true,


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

If you included the OneTrust inside the document head on the server instead of the body, it may happen that OneTrust finished loading the script before React was ready. In that case, OptanonWrapper was executed before the useEffect run, therefore the initial consent was wrong.

