### PR TITLE
Revert "chore(deps): update dependency slack to v4.14.0 (#287)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ slack_notify: &SLACK_NOTIFY
     branch_pattern: main
 
 orbs:
-  slack: circleci/slack@4.14.0
+  slack: circleci/slack@4.13.3
 
 jobs:
   install:


### PR DESCRIPTION
This reverts commit 96f010f85ecf50955d888adf985120f2f0f0236c.

References 
https://automotivesmg.slack.com/archives/C034EGP8GG0/p1726651654565229
https://github.com/CircleCI-Public/slack-orb/issues/461
