### PR TITLE
chore: move type dependencies to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@smg-automotive/cookie-consent-pkg",
       "version": "0.0.0-development",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "20.14.0"
-      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "28.0.0",
         "@rollup/plugin-node-resolve": "15.2.3",
@@ -20,6 +17,7 @@
         "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "14.5.2",
         "@types/jest": "29.5.12",
+        "@types/node": "20.14.0",
         "@types/react": "18.3.3",
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
@@ -3200,6 +3198,7 @@
       "version": "20.14.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
       "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -15292,7 +15291,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -18073,6 +18073,7 @@
       "version": "20.14.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
       "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -26703,7 +26704,8 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "14.5.2",
     "@types/jest": "29.5.12",
+    "@types/node": "20.14.0",
     "@types/react": "18.3.3",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
@@ -53,8 +54,5 @@
   "peerDependencies": {
     "react": ">= 16.0.0",
     "react-dom": ">= 16.0.0"
-  },
-  "dependencies": {
-    "@types/node": "20.14.0"
   }
 }


### PR DESCRIPTION
References [VSST-2696](https://smg-au.atlassian.net/browse/VSST-2696)

## Motivation and context

Moved type dependencies to dev dependencies.

Additional note: we can remove the @types/node dependency altogether since we don't appear to use any of node core libs within the project, but I opted not to do so because the project supports node.js runtime in context of build files. If we remove it and people start using node core libs, types will be available due to transient dependencies being installed and they will most likely end up being used as opposed to installing the @types/node which is sort of an anti-pattern.

## Before

Type deps as prod deps

## After

Type deps as dev deps

## How to test

`npm run typecheck` must pass

[VSST-2696]: https://smg-au.atlassian.net/browse/VSST-2696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ